### PR TITLE
Translate reflection tutorial to Korean

### DIFF
--- a/docs/docs/tutorials/reflection/reflection.ipynb
+++ b/docs/docs/tutorials/reflection/reflection.ipynb
@@ -10,15 +10,7 @@
    "id": "492f050f-3dc3-44fa-8fdc-03362afd5488",
    "metadata": {},
    "source": [
-    "# Reflection\n",
-    "\n",
-    "\n",
-    "In the context of LLM agent building, reflection refers to the process of prompting an LLM to observe its past steps (along with potential observations from tools/the environment) to assess the quality of the chosen actions.\n",
-    "This is then used downstream for things like re-planning, search, or evaluation.\n",
-    "\n",
-    "![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
-    "\n",
-    "This notebook demonstrates a very simple form of reflection in LangGraph."
+    "# 리플렉션\n\nLLM 에이전트를 구축하는 맥락에서 리플렉션은 LLM이 과거 단계(도구나 환경에서 얻은 관찰을 포함할 수 있음)를 살펴보고 선택한 행동의 품질을 평가하도록 프롬프트하는 과정을 의미합니다.\n이 과정은 재계획, 탐색, 평가와 같은 후속 작업에 활용됩니다.\n\n![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n\n이 노트북은 LangGraph에서 매우 단순한 형태의 리플렉션을 보여 줍니다.\n"
    ]
   },
   {
@@ -26,9 +18,7 @@
    "id": "3ef94e7e-c9a5-4eee-a865-acf411b5c235",
    "metadata": {},
    "source": [
-    "## Setup\n",
-    "\n",
-    "First, let's install our required packages and set our API keys"
+    "## 준비하기\n\n먼저 필요한 패키지를 설치하고 API 키를 설정하겠습니다\n"
    ]
   },
   {
@@ -68,12 +58,7 @@
    "id": "9182b7d5",
    "metadata": {},
    "source": [
-    "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
-    "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
-    "    </p>\n",
-    "</div>"
+    "<div class=\"admonition tip\">\n    <p class=\"admonition-title\">LangGraph 개발을 위해 <a href=\"https://smith.langchain.com\">LangSmith</a> 설정하기</p>\n    <p style=\"padding-top: 5px;\">\n        LangGraph 프로젝트에서 문제를 빠르게 파악하고 성능을 향상시키려면 LangSmith에 가입하세요. LangSmith는 LangGraph로 구축한 LLM 앱을 추적 데이터로 디버그하고, 테스트하고, 모니터링할 수 있게 해 줍니다 — 시작하는 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 자세히 확인할 수 있습니다.\n    </p>\n</div>\n"
    ]
   },
   {
@@ -81,9 +66,7 @@
    "id": "f27bcc4a-aaa5-46bd-8163-3e0e90cb66e6",
    "metadata": {},
    "source": [
-    "## Generate\n",
-    "\n",
-    "For our example, we will create a \"5 paragraph essay\" generator. First, create the generator:\n"
+    "## 생성하기\n\n이번 예제에서는 \"5단락 에세이\" 생성기를 만들어 보겠습니다. 먼저 생성기를 만듭니다:\n\n"
    ]
   },
   {
@@ -161,7 +144,7 @@
    "id": "b0b276e7-c392-4eec-be75-c77bd130379d",
    "metadata": {},
    "source": [
-    "### Reflect"
+    "### 되돌아보기\n"
    ]
   },
   {
@@ -238,9 +221,7 @@
    "id": "6daf926c-1174-4e96-91b9-57c57cfce40d",
    "metadata": {},
    "source": [
-    "### Repeat\n",
-    "\n",
-    "And... that's all there is too it! You can repeat in a loop for a fixed number of steps, or use an LLM (or other check) to decide when the finished product is good enough."
+    "### 반복하기\n\n그리고... 이게 전부입니다! 고정된 횟수만큼 루프를 반복하거나, LLM(또는 다른 검증)을 사용해 최종 결과가 충분히 만족스러운 시점을 판단할 수 있습니다.\n\n"
    ]
   },
   {
@@ -307,9 +288,7 @@
    "id": "b63a9d93-a14d-4e41-a4bb-a4cd31713f44",
    "metadata": {},
    "source": [
-    "## Define graph\n",
-    "\n",
-    "Now that we've shown each step in isolation, we can wire it up in a graph."
+    "## 그래프 정의하기\n\n각 단계를 개별적으로 살펴본 만큼 이제 그래프로 연결해 보겠습니다.\n\n"
    ]
   },
   {
@@ -605,9 +584,7 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "## Conclusion\n",
-    "\n",
-    "Now that you've applied reflection to an LLM agent, I'll note one thing: self-reflection is inherently cyclic: it is much more effective if the reflection step has additional context or feedback (from tool observations, checks, etc.). If, like in the scenario above, the reflection step simply prompts the LLM to reflect on its output, it can still benefit the output quality (since the LLM then has multiple \"shots\" at getting a good output), but it's less guaranteed.\n"
+    "## 마무리\n\nLLM 에이전트에 리플렉션을 적용해 보았으니 한 가지를 덧붙이겠습니다. 자기 반성은 본질적으로 순환적이어서, 반성 단계에 추가적인 맥락이나 피드백(도구 관찰, 검증 등)이 있을 때 훨씬 더 효과적입니다. 위의 시나리오처럼 반성 단계가 단순히 LLM에게 자신의 출력을 되돌아보라고 요청하는 경우에도 출력 품질에는 도움이 될 수 있습니다(LLM이 좋은 출력을 얻을 기회를 여러 번 갖게 되기 때문입니다). 다만 그 효과가 항상 보장되지는 않습니다.\n\n"
    ]
   }
  ],

--- a/examples/reflection/reflection.ipynb
+++ b/examples/reflection/reflection.ipynb
@@ -5,7 +5,7 @@
    "id": "658773a2",
    "metadata": {},
    "source": [
-    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb"
+    "이 파일은 https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb 로 이동했습니다."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate the reflection tutorial notebook markdown cells into Korean for localized guidance
- update the example reflection notebook message to Korean to point to the documentation location

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dd17bb428c832d87477e62ad84bb55